### PR TITLE
Remove the requirement for Add in external commit

### DIFF
--- a/draft-ietf-mls-protocol.md
+++ b/draft-ietf-mls-protocol.md
@@ -2996,10 +2996,8 @@ External Commits work like regular Commits, with a few differences:
 
 * The proposals included by value in an External Commit MUST meet the following
   conditions:
-  * There MUST be a single Add proposal that adds the new issuing new member to
-    the group
   * There MUST be a single ExternalInit proposal
-  * There MUST NOT be any Update proposals
+  * There MUST NOT be any Add or Update proposals
   * If a Remove proposal is present, then the `credential` and `endpoint_id` of
     the removed leaf MUST be the same as the corresponding values in the Add
     KeyPackage.
@@ -3007,7 +3005,9 @@ External Commits work like regular Commits, with a few differences:
   conditions:
   * There MUST NOT be any ExternalInit proposals
 * External Commits MUST contain a `path` field (and is therefore a "full"
-  Commit)
+  Commit).  The joiner is added at the leftmost free leaf node (just as if they
+  were added with an Add proposal), and the path is calculated relative to that
+  leaf node.
 * External Commits MUST be signed by the new member.  In particular, the
   signature on the enclosing MLSPlaintext MUST verify using the public key for
   the credential in the `leaf_key_package` of the `path` field.


### PR DESCRIPTION
Cherry pick https://github.com/mlswg/mls-protocol/issues/505 to align with what's actually implemented in openmls-0.4